### PR TITLE
Linux workaround for image recognition

### DIFF
--- a/Main/autoClicker.py
+++ b/Main/autoClicker.py
@@ -12,11 +12,6 @@ Features:
 - Can auto find and click on many images (Windows only)
 """
 
-# check if os is not windows 
-nonWindows = False
-if os.name != 'nt':
-    nonWindows = True
-    
 # ================================================================================================
 # SETTINGS
 delay = 0.001 # Set delay
@@ -46,8 +41,9 @@ print("Auto Clicker Starting\n"
       f"Start/Stop button: {startStopKey}\n"
       f"Frenzy button: {frenzyKey}\n")
 
-# Auto disable features if not supported on Linux (probs MacOS too)
-if nonWindows == True:
+# check if os is not windows
+# Auto disable features if not supported on Linux (probs MacOS too
+if os.name != 'nt':
     print("Auto snap to image & Frenzy mode is disabled as it is not supported on this OS z\nSorry, i'm working on implementing it currently")
     autoSnapToggle = False
     frenzyToggle = False

--- a/Main/autoClicker.py
+++ b/Main/autoClicker.py
@@ -110,7 +110,7 @@ def keyLogger(key): # Function for tracking key presses
         
         while True: # While true
             try:
-                for pos in pyautogui.locateAllOnScreen(frenzyPath, grayscale=True, confidence=0.7): # Locate all the images on the screen
+                for pos in pyautogui.locateAllOnScreen(frenzyPath, grayscale=True, confidence=0.5): # Locate all the images on the screen
                     pyautogui.moveTo(pos) # Move the mouse to the location
                     mouse.click(Button.left) # Click the button
                     

--- a/Main/autoClicker.py
+++ b/Main/autoClicker.py
@@ -11,6 +11,7 @@ Features:
 - Automatically moves mouse to image location (Winodws only)
 - Can auto find and click on many images (Windows only)
 """
+
 # check if os is not windows 
 if os.name != 'nt':
     nonWindows = True

--- a/Main/autoClicker.py
+++ b/Main/autoClicker.py
@@ -5,15 +5,16 @@ import time, threading, os, pyautogui
 """_summary_
 Auto clicker script with boundary check
 
-ONLY WORKS ON WINDOWS
-
 Features:
 - Clicks fast
 - Stops clicking when mouse is outside of a boundary
-- Automatically moves mouse to image location
-- Can auto find and click on many images
+- Automatically moves mouse to image location (Winodws only)
+- Can auto find and click on many images (Windows only)
 """
-
+# check if os is not windows 
+if os.name != 'nt':
+    nonWindows = True
+    
 # ================================================================================================
 # SETTINGS
 delay = 0.001 # Set delay
@@ -43,6 +44,10 @@ print("Auto Clicker Starting\n"
       f"Start/Stop button: {startStopKey}\n"
       f"Frenzy button: {frenzyKey}\n")
 
+if nonWindows == True:
+    print("Auto snap to image & Frenzy mode is disabled as it is not supported on this OS z\nSorry, i'm working on implementing it currently")
+    autoSnapToggle = False
+    frenzyToggle = False
 
 mouse = Controller() # Create mouse object
 clicking = False # Set clicking to false


### PR DESCRIPTION
Thought of a workaround for running on non windows machines.

Now that I've added a toggle for certian features, the program can just do a check for the OS and auto disable "autoSnapToggle" and "FrenzyToggle" to prevent errors